### PR TITLE
Síður fyrir hetjuval

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ LEÍ Reglubók
 League of Legends
 
 Uppfært 2026-01-13
-v1.0.4
+v1.0.4-dirty
 
 # Formáli
 
@@ -416,9 +416,10 @@ Mótstjórn er heimilt að koma í talrásina ef skyldi koma upp ástæða til �
 
 ### 2.4.11 Hetjuval (e. Champion Select).
 
-Lið bera ábyrgð á að setja upp hetjuval á [Draftlol](https://draftlol.dawe.gg) fyrir leik til að velja hetjur fyrir leik.
+Lið bera ábyrgð á að setja upp hetjuval á [Draftlol](https://draftlol.dawe.gg) eða [Drafterlol](https://drafter.lol) fyrir leik til að velja hetjur fyrir leik.
 
-Fyrirliði hvers liðs ber ábyrgð að senda hlekk (e. link) af hetjuvali á mótstjórn þegar hún er gerð.
+Fyrirliði hvers liðs ber ábyrgð að senda hlekk (e. link) af hetjuvali á mótstjórn inn á rás liðsins.
+Senda skal hlekkinn áður en hetjuvalið hefur byrjað.
 
 ### 2.4.12 Skiptingar í viðureignum
 

--- a/src/base.md
+++ b/src/base.md
@@ -400,9 +400,10 @@ Liðsmenn hafa ekki heimild til þess að vera inni á öðrum talrásum meðan 
 Mótstjórn er heimilt að koma í talrásina ef skyldi koma upp ástæða til þess að tala við liðið eða þjálfara liðs.
 
 ### 2.4.11 Hetjuval (e. Champion Select).
-Lið bera ábyrgð á að setja upp hetjuval á [Draftlol](https://draftlol.dawe.gg) fyrir leik til að velja hetjur fyrir leik. 
+Lið bera ábyrgð á að setja upp hetjuval á [Draftlol](https://draftlol.dawe.gg) eða [Drafterlol](https://drafter.lol) fyrir leik til að velja hetjur fyrir leik. 
 
-Fyrirliði hvers liðs ber ábyrgð að senda hlekk (e. link) af hetjuvali á mótstjórn þegar hún er gerð.
+Fyrirliði hvers liðs ber ábyrgð að senda hlekk (e. link) af hetjuvali á mótstjórn inn á rás liðsins.
+Senda skal hlekkinn áður en hetjuvalið hefur byrjað.
 
 ### 2.4.12 Skiptingar í viðureignum
 Lið má skipta um leikmann á milli leikja í einvígi, það er milli leiks 1 og leiks 2 og svo framvegis.


### PR DESCRIPTION
Leyfa aðra síðu í hetjuvali sem er þegar notuð. Taka fram að senda skall hetjuval á rás liðsins áður en hetjuvalið hefst.

Þessu er breytt því þessi síða er þegur notuð, því er verið að aðlaga reglur að raunveruleikanum.
Hin breytingin er í raun bara itrekun á því sem mótstjórn hefur sagt í skilaboðum.
Tilgangur er að mótstjórn hafi möguleikan á að fylgjast með draft í beinni og geti breytt um útsendingarleik þá ef eitthvað fer úrskeiðis með áætlaða leikinn.

Closes #5 