### PR TITLE
Fjarlægja þörf á replay file

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ Deildin áskilur sér þann rétt að halda eftir greiðslum ef að keppandi eð
 #### 2.3.2.2 Keppnisdagar
 
 Keppnisdagar í KIA deildinni eru mánudaga frá kl. 19:00 - 22:00 frá 19. janúar til 12. apríl.
-Liðum ber að senda replay file á mótastjóra að leik loknum.
 
 ### 2.3.3 Áhugamannadeildir - Fyrsta deild og niður
 
@@ -369,7 +368,6 @@ Ef lið fylgja ekki þessarri reglu fá þau viðvörun og ef lið hefur fengið
 
 Niðurstöður leikja eru sjálfkrafa skráðar í kerfi Challengermode.
 Ef kerfið virkar ekki þarf að senda mótastjóra screenshot með niðurstöðum úr leik á viðeigandi discord rás með *gameID* og pick/ban upplýsingum.
-Senda þarf replay file á mótastjóra úr hverjum leik, strax eftir hvern leik.
 
 ### 2.4.4 Pása á leik
 

--- a/src/base.md
+++ b/src/base.md
@@ -288,7 +288,6 @@ Deildin áskilur sér þann rétt að halda eftir greiðslum ef að keppandi eð
 #### 2.3.2.2 Keppnisdagar
 
 Keppnisdagar í KIA deildinni eru mánudaga frá  kl. 19:00 - 22:00 frá 19. janúar til 12. apríl.
-Liðum ber að senda replay file á mótastjóra að leik loknum.
 
 ### 2.3.3 Áhugamannadeildir - Fyrsta deild og niður
 
@@ -354,7 +353,6 @@ Ef lið fylgja ekki þessarri reglu fá þau viðvörun og ef lið hefur fengið
 
 Niðurstöður leikja eru sjálfkrafa skráðar í kerfi Challengermode.
 Ef kerfið virkar ekki þarf að senda mótastjóra screenshot með niðurstöðum úr leik á viðeigandi discord rás með *gameID* og pick/ban upplýsingum.
-Senda þarf replay file á mótastjóra úr hverjum leik, strax eftir hvern leik.
 
 ### 2.4.4 Pása á leik
 


### PR DESCRIPTION
Hugmyndin bakvið replay file tengdist því að geta staðfest hvort leikmenn væri að notast við ólögmætan spilara sem þykist vera annar spilari (e. ringer).
Ekki var búið að áætla hvernig lið ættu að uppfylla skilyrðin á þessum replays.
Krafan hefði verið sú að senda upptöku frá hverjum leikmanni (e. POV) með hljóði.
Þetta er því fjarlægt hér, allavega í bili.

Closes #6 